### PR TITLE
EV_ONESHOT -> EV_CLEAR

### DIFF
--- a/utils.h
+++ b/utils.h
@@ -27,20 +27,6 @@
 #include <pthread.h>
 
 
-/* struct kevent is declared slightly differently on the different BSDs.
- * This macros will help to avoid cast warnings on the supported platforms.
- */
-#if defined(__NetBSD__)
-#  define INDEX_TO_UDATA(X) (X)
-#  define UDATA_TO_INDEX(X) (X)
-#elif defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
-#  define INDEX_TO_UDATA(X) ((void *)(uintptr_t)X)
-#  define UDATA_TO_INDEX(X) ((uintptr_t)X)
-#else
-#  error Currently unsupported
-#endif
-
-
 char* path_concat (const char *dir, const char *file);
 
 struct inotify_event* create_inotify_event (int         wd,

--- a/watch.c
+++ b/watch.c
@@ -84,7 +84,6 @@ _file_information (int fd, int *is_dir, ino_t *inode)
  * @param[in]     path       A full path to a file.
  * @param[in]     entry_name A name of a watched file (for dependency watches).
  * @param[in]     flags      A combination of the inotify watch flags.
- * @param[in]     index      The index of a watch in the worker sets.
  * @return 0 on success, -1 on failure.
  **/
 int
@@ -93,8 +92,7 @@ watch_init (watch         *w,
             struct kevent *kv,
             const char    *path,
             const char    *entry_name,
-            uint32_t       flags,
-            int            index)
+            uint32_t       flags)
 {
     assert (w != NULL);
     assert (kv != NULL);
@@ -131,7 +129,7 @@ watch_init (watch         *w,
             EV_ADD | EV_ENABLE | EV_CLEAR,
             inotify_to_kqueue (flags, w->is_really_dir, is_subwatch),
             0,
-            INDEX_TO_UDATA (index));
+            NULL);
 
     return 0;
 }

--- a/watch.c
+++ b/watch.c
@@ -128,7 +128,7 @@ watch_init (watch         *w,
     EV_SET (kv,
             w->fd,
             EVFILT_VNODE,
-            EV_ADD | EV_ENABLE | EV_ONESHOT,
+            EV_ADD | EV_ENABLE | EV_CLEAR,
             inotify_to_kqueue (flags, w->is_really_dir, is_subwatch),
             0,
             INDEX_TO_UDATA (index));

--- a/watch.h
+++ b/watch.h
@@ -60,8 +60,7 @@ int watch_init (watch         *w,
                 struct kevent *kv,
                 const char    *path,
                 const char    *entry_name,
-                uint32_t       flags,
-                int            index);
+                uint32_t       flags);
 
 int  watch_reopen (watch *w);
 void watch_free   (watch *w);

--- a/watch.h
+++ b/watch.h
@@ -23,7 +23,6 @@
 #ifndef __WATCH_H__
 #define __WATCH_H__
 
-#include <sys/event.h> /* kevent */
 #include <stdint.h>    /* uint32_t */
 #include <dirent.h>    /* ino_t */
 
@@ -47,8 +46,6 @@ typedef struct watch {
     int fd;                   /* file descriptor of a watched entry */
     ino_t inode;              /* inode number for the watched entry */
 
-    struct kevent *event;     /* a pointer to the associated kevent */
-
     union {
         dep_list *deps;       /* dependencies for an user-defined watch */
         struct watch *parent; /* parent watch for an automatic (dependency) watch */
@@ -58,7 +55,6 @@ typedef struct watch {
 
 int watch_init (watch         *w,
                 watch_type_t   watch_type,
-                struct kevent *kv,
                 int            kq,
                 const char    *path,
                 const char    *entry_name,

--- a/watch.h
+++ b/watch.h
@@ -55,15 +55,18 @@ typedef struct watch {
     };
 } watch;
 
+
 int watch_init (watch         *w,
                 watch_type_t   watch_type,
                 struct kevent *kv,
+                int            kq,
                 const char    *path,
                 const char    *entry_name,
                 uint32_t       flags);
 
-int  watch_reopen (watch *w);
+int  watch_reopen (watch *w, int kq);
 void watch_free   (watch *w);
 
+int  watch_register_event (watch *w, int kq, uint32_t fflags);
 
 #endif /* __WATCH_H__ */

--- a/worker-sets.c
+++ b/worker-sets.c
@@ -59,7 +59,7 @@ worker_sets_init (worker_sets *ws,
     EV_SET (&ws->events[0],
             fd,
             EVFILT_READ,
-            EV_ADD | EV_ENABLE | EV_ONESHOT,
+            EV_ADD | EV_ENABLE | EV_CLEAR,
             NOTE_LOWAT,
             1,
             0);

--- a/worker-sets.c
+++ b/worker-sets.c
@@ -41,12 +41,10 @@
  * Initialize the worker sets.
  *
  * @param[in] ws A pointer to the worker sets.
- * @param[in] fd A control file descriptor.
  * @return 0 on success, -1 on failure.
  **/
 int
-worker_sets_init (worker_sets *ws,
-                  int          fd)
+worker_sets_init (worker_sets *ws)
 {
     assert (ws != NULL);
 
@@ -56,14 +54,7 @@ worker_sets_init (worker_sets *ws,
         return -1;
     }
 
-    EV_SET (&ws->events[0],
-            fd,
-            EVFILT_READ,
-            EV_ADD | EV_ENABLE | EV_CLEAR,
-            NOTE_LOWAT,
-            1,
-            0);
-    ws->length = 1;
+    ws->length = 0;
     return 0;
 }
 
@@ -84,15 +75,6 @@ worker_sets_extend (worker_sets *ws,
         long to_allocate = ws->allocated + count + WS_RESERVED;
 
         void *ptr = NULL;
-        ptr = realloc (ws->events, sizeof (struct kevent) * to_allocate);
-        if (ptr == NULL) {
-            perror_msg ("Failed to extend events memory in the worker sets "
-                        "to %d items",
-                        to_allocate);
-            return -1;
-        }
-        ws->events = ptr;
-
         ptr = realloc (ws->watches, sizeof (struct watch *) * to_allocate);
         if (ptr == NULL) {
             perror_msg ("Failed to extend watches memory in the worker sets "
@@ -117,7 +99,6 @@ void
 worker_sets_free (worker_sets *ws)
 {
     assert (ws != NULL);
-    assert (ws->events != NULL);
     assert (ws->watches != NULL);
 
     size_t i;
@@ -127,7 +108,6 @@ worker_sets_free (worker_sets *ws)
         }
     }
 
-    free (ws->events);
     free (ws->watches);
     memset (ws, 0, sizeof (worker_sets));
 }

--- a/worker-sets.h
+++ b/worker-sets.h
@@ -29,13 +29,12 @@
 #include "watch.h"
 
 typedef struct worker_sets {
-    struct kevent *events;    /* kevent entries */
     struct watch **watches;   /* appropriate watches with additional info */
     size_t length;            /* size of active entries */
     size_t allocated;         /* size of allocated entries */
 } worker_sets;
 
-int  worker_sets_init   (worker_sets *ws, int fd);
+int  worker_sets_init   (worker_sets *ws);
 int  worker_sets_extend (worker_sets *ws, int count);
 void worker_sets_free   (worker_sets *ws);
 

--- a/worker-thread.c
+++ b/worker-thread.c
@@ -279,7 +279,7 @@ handle_replaced (void       *udata,
     }
 
     int i;
-    for (i = 1; i < ctx->wrk->sets.length; i++) {
+    for (i = 0; i < ctx->wrk->sets.length; i++) {
         watch *iw = ctx->wrk->sets.watches[i];
         if (iw && iw->parent == ctx->w && strcmp (to_path, iw->filename) == 0) {
             dep_list *dl = dl_create (iw->filename, iw->inode);
@@ -532,7 +532,7 @@ produce_notifications (worker *wrk, struct kevent *event)
     watch *w = NULL;
     size_t i;
 
-    for (i = 1; i < wrk->sets.length; i++) {
+    for (i = 0; i < wrk->sets.length; i++) {
         if (event->ident == wrk->sets.watches[i]->fd) {
             w = wrk->sets.watches[i];
             break;

--- a/worker-thread.c
+++ b/worker-thread.c
@@ -529,7 +529,16 @@ produce_notifications (worker *wrk, struct kevent *event)
     assert (wrk != NULL);
     assert (event != NULL);
 
-    watch *w = wrk->sets.watches[UDATA_TO_INDEX (event->udata)];
+    watch *w = NULL;
+    size_t i;
+
+    for (i = 1; i < wrk->sets.length; i++) {
+        if (event->ident == wrk->sets.watches[i]->fd) {
+            w = wrk->sets.watches[i];
+            break;
+        }
+    }
+    assert (w != NULL);
 
     uint32_t flags = event->fflags;
 

--- a/worker-thread.c
+++ b/worker-thread.c
@@ -318,7 +318,7 @@ handle_overwritten (void *udata, const char *path, ino_t inode)
         watch *wi = ctx->wrk->sets.watches[i];
         if (wi && (strcmp (wi->filename, path) == 0)
             && wi->parent == ctx->w) {
-            if (watch_reopen (wi) == -1) {
+            if (watch_reopen (wi, ctx->wrk->kq) == -1) {
                 /* I dont know, what to do */
                 /* Not a very beautiful way to remove a single dependency */
                 dep_list *dl = dl_create (wi->filename, wi->inode);
@@ -611,12 +611,7 @@ worker_thread (void *arg)
     for (;;) {
         struct kevent received;
 
-        int ret = kevent (wrk->kq,
-                          wrk->sets.events,
-                          wrk->sets.length,
-                          &received,
-                          1,
-                          NULL);
+        int ret = kevent (wrk->kq, NULL, 0, &received, 1, NULL);
         if (ret == -1) {
             perror_msg ("kevent failed");
             continue;

--- a/worker.c
+++ b/worker.c
@@ -302,8 +302,7 @@ worker_start_watching (worker      *wrk,
                     &wrk->sets.events[i],
                     path,
                     entry_name,
-                    flags,
-                    i)
+                    flags)
         == -1) {
         watch_free (wrk->sets.watches[i]);
         wrk->sets.watches[i] = NULL;
@@ -487,7 +486,6 @@ worker_remove_many (worker *wrk, watch *parent, const dep_list *items, int remov
         /* If the control reached here, keep this item */
         if (i != j) {
             wrk->sets.events[j] = wrk->sets.events[i];
-            wrk->sets.events[j].udata = INDEX_TO_UDATA (j);
             wrk->sets.watches[j] = w;
             wrk->sets.watches[j]->event = &wrk->sets.events[j];
         }

--- a/worker.h
+++ b/worker.h
@@ -70,7 +70,7 @@ typedef struct {
     int kq;                /* kqueue descriptor */
     volatile int io[2];    /* a socket pair */
     pthread_t thread;      /* worker thread */
-    worker_sets sets;      /* kqueue events, filenames, etc */
+    worker_sets sets;      /* filenames, etc */
     volatile int closed;   /* closed flag */
 
     pthread_mutex_t mutex; /* worker mutex */


### PR DESCRIPTION
EV_ONESHOT -> EV_CLEAR. Now we don`t lose any events and don`t have to register kqueue changes "over and over again"

One drawback of proposed changes is a lose of watch creation atomicity. Now we register kqueue events one by one rather then all at once. This is done due to complicated error handling in latter case: http://doc.geoffgarside.co.uk/kqueue/kqerror.html