### PR TITLE
Integrate dmatveev7

### DIFF
--- a/compat.c
+++ b/compat.c
@@ -20,7 +20,17 @@
   THE SOFTWARE.
 *******************************************************************************/
 
+#include <sys/param.h> /* MAXPATHLEN */
+#include <sys/types.h>
+#include <sys/stat.h>  /* stat */
+
 #include <assert.h>
+#include <dirent.h> /* opendir */
+#include <errno.h>  /* errno */
+#include <fcntl.h>  /* fcntl */
+#include <limits.h> /* PATH_MAX */
+#include <stdarg.h> /* va_start */
+#include <stdlib.h> /* malloc */
 #include <string.h> /* memset */
 
 #include "compat.h"
@@ -100,3 +110,331 @@ pthread_barrier_destroy (pthread_barrier_t *impl)
     impl->sleeping = 0;
 }
 #endif /* HAVE_PTHREAD_BARRIER */
+
+#ifdef BUILD_LIBRARY
+#ifndef HAVE_ATFUNCS
+typedef struct dirpath_t {
+    ino_t inode;              /* inode number */
+    dev_t dev;                /* device number */
+    char *path;               /* full path to inode */
+    RB_ENTRY(dirpath_t) link; /* RB tree links */
+} dirpath_t;
+
+/* directory path cache */
+static RB_HEAD(dp, dirpath_t) dirs = RB_INITIALIZER (&dirs);
+/* directory path cache mutex */
+static pthread_mutex_t dirs_mtx = PTHREAD_MUTEX_INITIALIZER;
+
+/**
+ * Custom comparison function that can compare directory inode values
+ * through pointers passed by RB tree functions
+ *
+ * @param[in] dp1 A pointer to a first directory to compare
+ * @param[in] dp2 A pointer to a second directory to compare
+ * @return An -1, 0, or +1 if the first inode is considered to be respectively
+ *     less than, equal to, or greater than the second one.
+ **/
+static int
+dirpath_cmp (dirpath_t *dp1, dirpath_t *dp2)
+{
+    if (dp1->dev == dp2->dev)
+        return ((dp1->inode > dp2->inode) - (dp1->inode < dp2->inode));
+    else
+        return ((dp1->dev > dp2->dev) - (dp1->dev < dp2->dev));
+}
+
+RB_GENERATE(dp, dirpath_t, link, dirpath_cmp);
+
+/**
+ * Returns a pointer to the absolute pathname of the directory by filedes
+ * NOTE: It uses unsafe fchdir if no F_GETPATH fcntl have been found
+ *
+ * @param[in] fd A file descriptor of opened directory
+ * @return a pointer to the pathname on success, NULL otherwise
+ **/
+static char *
+fd_getpath (int fd)
+{
+    assert (fd != -1);
+
+    char *path = NULL;
+    DIR *save;
+    struct stat st;
+
+    if (fstat (fd, &st) == -1) {
+        return NULL;
+    }
+
+    if (!S_ISDIR (st.st_mode)) {
+        errno = ENOTDIR;
+        return NULL;
+    }
+
+    if (st.st_nlink == 0) {
+        errno = ENOENT;
+        return NULL;
+    }
+
+#if defined (F_GETPATH)
+    path = malloc (MAXPATHLEN);
+    if (path != NULL && fcntl (fd, F_GETPATH, path) == -1) {
+        free (path);
+        path = NULL;
+    }
+#elif defined (ENABLE_UNSAFE_FCHDIR)
+    /*
+     * Using of this code path can be unsafe in multithreading applications as
+     * following code do a temporary change of global current working directory
+     * via fchdir call. Consider renaming of watched directory as relatively
+     * rare operation so catching such a race is unlikely
+     */
+    save = opendir(".");
+
+    if (fchdir (fd) == 0) {
+        path = malloc (PATH_MAX);
+        if (path != NULL && getcwd (path, PATH_MAX) == NULL) {
+            free (path);
+            path = NULL;
+        }
+    }
+
+    if (save != NULL) {
+        int saved_errno = errno;
+        fchdir (dirfd (save));
+        closedir (save);
+        errno = saved_errno;
+    }
+#endif /* ENABLE_UNSAFE_FCHDIR && F_GETPATH */
+
+    return path;
+}
+
+/**
+ * Remove directory path from directory path cache.
+ * Should be called with dirs_mtx mutex held
+ *
+ * @param [in] dir A pointer to a directory to remove from cache
+ **/
+static void
+dir_remove (dirpath_t *dir)
+{
+    if (dir->path != NULL) {
+        free (dir->path);
+    }
+    RB_REMOVE (dp, &dirs, dir);
+    free (dir);
+}
+
+/**
+ * Insert directory path into directory path cache.
+ * Should be called with dirs_mtx mutex held
+ *
+ * @param [in] path  A directory path to be cached
+ * @param [in] inode A inode number of cached directory path
+ * @param [in] dev   A device number of cached directory path
+ * @return A pointer to allocated cache entry
+ **/
+static dirpath_t *
+dir_insert (const char* path, ino_t inode, dev_t dev)
+{
+    assert (path != NULL);
+
+    dirpath_t *newdp, *olddp;
+
+    newdp = calloc (1, sizeof (dirpath_t));
+    if (newdp == NULL) {
+        return NULL;
+    }
+
+    newdp->inode = inode;
+    newdp->dev = dev;
+
+    olddp = RB_FIND (dp, &dirs, newdp);
+    if (olddp != NULL) {
+        free (newdp);
+        if (strcmp (path, olddp->path)) {
+            free (olddp->path);
+            olddp->path = strdup (path);
+        }
+        newdp = olddp;
+    } else {
+        newdp->path = strdup (path);
+        RB_INSERT (dp, &dirs, newdp);
+    }
+
+    if (newdp->path == NULL) {
+        dir_remove (newdp);
+        newdp = NULL;
+    }
+
+    return newdp;
+}
+
+/**
+ * Find cached directory path corresponding a given inode number
+ *
+ * @param[in] fd A file descriptor of opened directory
+ * @return a pointer to the pathname on success, NULL otherwise
+ **/
+static char *
+fd_getpath_cached (int fd)
+{
+    assert (fd != -1);
+
+    dirpath_t find, *dir;
+    struct stat st1, st2;
+    char *path;
+
+    if (fstat (fd, &st1) == -1) {
+        return NULL;
+    }
+
+    if (!S_ISDIR (st1.st_mode)) {
+        errno = ENOTDIR;
+        return NULL;
+    }
+
+    find.inode = st1.st_ino;
+    find.dev = st1.st_dev;
+
+    pthread_mutex_lock (&dirs_mtx);
+
+    dir = RB_FIND (dp, &dirs, &find);
+    if (dir == NULL || stat (dir->path, &st2) != 0
+      || dir->inode != st2.st_ino || dir->dev != st2.st_dev) {
+
+        path = fd_getpath (fd);
+        if (path != NULL) {
+            dir = dir_insert (path, st1.st_ino, st1.st_dev);
+            free (path);
+        } else {
+            if (dir != NULL) {
+                dir_remove (dir);
+                dir = NULL;
+            }
+        }
+    }
+
+    pthread_mutex_unlock (&dirs_mtx);
+
+    return dir != NULL ? dir->path : NULL;
+}
+
+/**
+ * Create a file path using its name and a path to its directory.
+ *
+ * @param[in] dir  A path to a file directory. May end with a '/'.
+ * @param[in] file File name.
+ * @return A concatenated path. Should be freed with free().
+ **/
+static char*
+path_concat (const char *dir, const char *file)
+{
+    assert (dir != NULL);
+    assert (file != NULL);
+
+    size_t dir_len, file_len, alloc_sz;
+    char *path;
+
+    dir_len = strlen (dir);
+    file_len = strlen (file);
+    alloc_sz = dir_len + file_len + 2;
+
+    path = malloc (alloc_sz);
+    if (path != NULL) {
+
+        strlcpy (path, dir, alloc_sz);
+
+        if (dir[dir_len - 1] != '/') {
+            ++dir_len;
+            path[dir_len - 1] = '/';
+        }
+
+        strlcpy (path + dir_len, file, file_len + 1);
+    }
+
+    return path;
+}
+
+/**
+ * Create a file path using its name and a filedes of its directory.
+ *
+ * @param[in] fd   A file descriptor of opened directory.
+ * @param[in] file File name.
+ * @return A concatenated path. Should be freed with free().
+ **/
+static char*
+fd_concat (int fd, const char *file)
+{
+    char *path = NULL;
+    struct stat st;
+
+    if (fd == AT_FDCWD) {
+
+        if (stat (file, &st) != -1
+          && S_ISDIR (st.st_mode)
+          && (path = realpath (file, NULL)) != NULL) {
+
+            pthread_mutex_lock (&dirs_mtx);
+            dir_insert (path, st.st_ino, st.st_dev);
+            pthread_mutex_unlock (&dirs_mtx);
+        } else {
+            path = strdup (file);
+        }
+    } else {
+
+        char *dirpath = fd_getpath_cached (fd);
+        if (dirpath != NULL) {
+            path = path_concat (dirpath, file);
+        }
+    }
+
+    return path;
+}
+#endif /* !HAVE_ATFUNCS */
+
+#ifndef HAVE_OPENAT
+int
+openat (int fd, const char *path, int flags, ...)
+{
+    char *fullpath;
+    int newfd, save_errno;
+    mode_t mode;
+    va_list ap;
+
+    if (flags & O_CREAT) {
+        va_start(ap, flags);
+        mode = va_arg(ap, int);
+        va_end(ap);
+    } else {
+        mode = 0;
+    }
+
+    fullpath = fd_concat (fd, path);
+    if (fullpath == NULL) {
+        return -1;
+    }
+
+    newfd = open (fullpath, flags, mode);
+
+    save_errno = errno;
+    free (fullpath);
+    errno = save_errno;
+
+    return newfd;
+}
+#endif /* HAVE_OPENAT */
+
+#ifndef HAVE_FDOPENDIR
+DIR *
+fdopendir (int fd)
+{
+    char *dirpath = fd_getpath_cached (fd);
+    if (dirpath == NULL) {
+        return NULL;
+    }
+
+    return opendir (dirpath);
+}
+#endif /* HAVE_FDOPENDIR */
+#endif /* BUILD_LIBRARY */

--- a/compat.h
+++ b/compat.h
@@ -28,6 +28,14 @@
 #ifdef BUILD_LIBRARY
 #include <sys/types.h>
 #include <sys/queue.h>
+#ifdef __APPLE__
+#include </System/Library/Frameworks/Kernel.framework/Versions/Current/Headers/libkern/tree.h>
+#else
+#include <sys/tree.h>  /* RB tree macroses */
+#endif
+
+#include <dirent.h>
+#include <fcntl.h>
 #endif /* BUILD_LIBRARY */
 #include <pthread.h>
 
@@ -65,5 +73,18 @@ void pthread_barrier_init    (pthread_barrier_t *impl,
 void pthread_barrier_wait    (pthread_barrier_t *impl);
 void pthread_barrier_destroy (pthread_barrier_t *impl);
 #endif
+
+#ifdef BUILD_LIBRARY
+#ifndef AT_FDCWD
+#define AT_FDCWD		-100
+#endif
+
+#ifndef HAVE_OPENAT
+int openat (int fd, const char *path, int flags, ...);
+#endif
+#ifndef HAVE_FDOPENDIR
+DIR *fdopendir (int fd);
+#endif
+#endif /* BUILD_LIBRARY */
 
 #endif /* __COMPAT_H__ */

--- a/configure.ac
+++ b/configure.ac
@@ -68,4 +68,34 @@ AC_COMPILE_IFELSE(
 )
 
 
+AC_ARG_ENABLE([unsafe_fchdir],
+    AS_HELP_STRING([--enable-unsafe-fchdir], [allow unsafe use of fchdir to track of watched directory path changes on its renaming]),
+[
+    AC_DEFINE([ENABLE_UNSAFE_FCHDIR],[1],[Allow to use of fchdir to track of watched directory path changes])
+    enable_unsafe_fchdir=yes
+],
+    enable_unsafe_fchdir=no
+)
+
+atfuncs_support=yes
+AC_CHECK_FUNCS(openat fdopendir,,atfuncs_support=no)
+if test "$atfuncs_support" = "yes"; then
+    AC_DEFINE([HAVE_ATFUNCS],[1],[Define to 1 if relative pathname functions detected])
+fi
+
+AC_MSG_CHECKING(for F_GETPATH in fcntl.h)
+AC_COMPILE_IFELSE(
+    [AC_LANG_PROGRAM([@%:@include <fcntl.h>], [int a = F_GETPATH;])],
+    f_getpath_support=yes,
+    f_getpath_support=no
+)
+AC_MSG_RESULT($f_getpath_support)
+
+if test "$atfuncs_support" = "no" -a \
+        "$f_getpath_support" = "no" -a \
+        "$enable_unsafe_fchdir" = "no"; then
+    AC_MSG_WARN([Neither POSIX.1-2008 relative pathname functions nor F_GETPATH fcntl have been found. Watched directory renamings are untracked. You can specify --enable-unsafe-fchdir to avoid this])
+fi
+
+
 AC_OUTPUT

--- a/dep-list.h
+++ b/dep-list.h
@@ -70,7 +70,7 @@ void      dl_print        (const dep_list *dl);
 dep_list* dl_shallow_copy (const dep_list *dl);
 void      dl_shallow_free (dep_list *dl);
 void      dl_free         (dep_list *dl);
-dep_list* dl_listing      (const char *path);
+dep_list* dl_listing      (int fd);
 
 int
 dl_calculate (dep_list            *before,

--- a/tests/notifications_dir_test.cc
+++ b/tests/notifications_dir_test.cc
@@ -283,6 +283,26 @@ void notifications_dir_test::run ()
 
 
     cons.output.reset ();
+    cons.input.receive ();
+
+    system ("mv ntfsdt-working-2/bar ntfsdt-working-2/foo");
+
+    cons.output.wait ();
+    received = cons.output.registered ();
+    should ("receive events from a files in directory after directory has been moved",
+            contains (received, event ("bar", wid, IN_MOVED_FROM))
+            && contains (received, event ("foo", wid, IN_MOVED_TO)));
+
+    /* resetup watch again to not be dependent on success of previous test */
+    cons.input.setup ("ntfsdt-working-2",
+                      IN_ATTRIB | IN_MODIFY
+                      | IN_CREATE | IN_DELETE
+                      | IN_MOVED_FROM | IN_MOVED_TO
+                      | IN_MOVE_SELF | IN_DELETE_SELF);
+    cons.output.wait ();
+    wid = cons.output.added_watch_id ();
+
+    cons.output.reset ();
     cons.input.receive (4);
 
     system ("rm -rf ntfsdt-working-2");
@@ -291,8 +311,8 @@ void notifications_dir_test::run ()
     received = cons.output.registered ();
     should ("receive IN_DELETE for a file \'one\' in a directory on removing a directory",
             contains (received, event ("one", wid, IN_DELETE)));
-    should ("receive IN_DELETE for a file \'bar\' in a directory on removing a directory",
-            contains (received, event ("bar", wid, IN_DELETE)));
+    should ("receive IN_DELETE for a file \'foo\' in a directory on removing a directory",
+            contains (received, event ("foo", wid, IN_DELETE)));
     should ("receive IN_DELETE_SELF on removing a directory",
             contains (received, event ("", wid, IN_DELETE_SELF)));
     should ("receive IN_IGNORED on removing a directory",

--- a/utils.c
+++ b/utils.c
@@ -46,39 +46,6 @@
 #include "config.h"
 
 /**
- * Create a file path using its name and a path to its directory.
- *
- * @param[in] dir  A path to a file directory. May end with a '/'.
- * @param[in] file File name.
- * @return A concatenated path. Should be freed with free().
- **/
-char*
-path_concat (const char *dir, const char *file)
-{
-    size_t dir_len = strlen (dir);
-    size_t file_len = strlen (file);
-    size_t alloc_sz = dir_len + file_len + 2;
-
-    char *path = malloc (alloc_sz);
-    if (path == NULL) {
-        perror_msg ("Failed to allocate memory (%d bytes) "
-                    "for path concatenation",
-                    alloc_sz);
-        return NULL;
-    }
-
-    strlcpy (path, dir, alloc_sz);
-
-    if (dir[dir_len - 1] != '/') {
-        ++dir_len;
-        path[dir_len - 1] = '/';
-    }
-
-    strlcpy (path + dir_len, file, file_len + 1);
-    return path;
-}
-
-/**
  * Create a new inotify event.
  *
  * @param[in] wd     An associated watch's id.

--- a/utils.h
+++ b/utils.h
@@ -28,8 +28,6 @@
 #include <stdint.h> /* uint32_t */
 #include <pthread.h>
 
-char* path_concat (const char *dir, const char *file);
-
 struct inotify_event* create_inotify_event (int         wd,
                                             uint32_t    mask,
                                             uint32_t    cookie,

--- a/watch.c
+++ b/watch.c
@@ -32,6 +32,7 @@
 #include <stdio.h>    /* snprintf */
 
 #include "utils.h"
+#include "compat.h"
 #include "conversions.h"
 #include "watch.h"
 #include "sys/inotify.h"
@@ -106,18 +107,18 @@ watch_register_event (watch *w, int kq, uint32_t fflags)
 /**
  * Opens a file descriptor of kqueue watch
  *
- * @param[in] dir  A path to a parent directory or NULL
- * @param[in] path A pointer to filename
+ * @param[in] dirfd A filedes of parent directory or AT_FDCWD.
+ * @param[in] path  A pointer to filename
  * @return A file descriptor of opened kqueue watch
  **/
 int
-watch_open (const char *dir, const char *path)
+watch_open (int dirfd, const char *path)
 {
     assert (path != NULL);
 
-    char *fullpath = (dir != NULL) ? path_concat (dir, path) : strdup (path);
-    int fd = open (fullpath, O_RDONLY);
-    free (fullpath);
+    int openflags = O_RDONLY;
+
+    int fd = openat (dirfd, path, openflags);
 
     return fd;
 }

--- a/watch.h
+++ b/watch.h
@@ -52,7 +52,7 @@ typedef struct watch {
     };
 } watch;
 
-int    watch_open (const char *dir, const char *path);
+int    watch_open (int dirfd, const char *path);
 watch *watch_init (watch_type_t   watch_type,
                    int            kq,
                    const char    *path,

--- a/watch.h
+++ b/watch.h
@@ -52,12 +52,12 @@ typedef struct watch {
     };
 } watch;
 
-
+int watch_open (const char *dir, const char *path);
 int watch_init (watch         *w,
                 watch_type_t   watch_type,
                 int            kq,
                 const char    *path,
-                const char    *entry_name,
+                int            fd,
                 uint32_t       flags);
 
 void watch_free   (watch *w);

--- a/watch.h
+++ b/watch.h
@@ -52,16 +52,15 @@ typedef struct watch {
     };
 } watch;
 
-int watch_open (const char *dir, const char *path);
-int watch_init (watch         *w,
-                watch_type_t   watch_type,
-                int            kq,
-                const char    *path,
-                int            fd,
-                uint32_t       flags);
+int    watch_open (const char *dir, const char *path);
+watch *watch_init (watch_type_t   watch_type,
+                   int            kq,
+                   const char    *path,
+                   int            fd,
+                   uint32_t       flags);
 
-void watch_free   (watch *w);
+void   watch_free (watch *w);
 
-int  watch_register_event (watch *w, int kq, uint32_t fflags);
+int    watch_register_event (watch *w, int kq, uint32_t fflags);
 
 #endif /* __WATCH_H__ */

--- a/worker-thread.c
+++ b/worker-thread.c
@@ -368,7 +368,7 @@ produce_directory_diff (worker *wrk, watch *w, struct kevent *event)
 
     dep_list *was = NULL, *now = NULL;
     was = w->deps;
-    now = dl_listing (w->filename);
+    now = dl_listing (w->fd);
     if (now == NULL) {
         perror_msg ("Failed to create a listing for directory %s",
                     w->filename);

--- a/worker-thread.c
+++ b/worker-thread.c
@@ -22,7 +22,6 @@
 
 #include <stddef.h> /* NULL */
 #include <assert.h>
-#include <unistd.h> /* write */
 #include <stdlib.h> /* calloc, realloc */
 #include <string.h> /* memset */
 #include <stdio.h>
@@ -186,21 +185,14 @@ handle_added (void *udata, dep_item *di)
     assert (ctx->w != NULL);
 
     int addMask = 0;
-    char *npath = path_concat (ctx->w->filename, di->path);
-    if (npath != NULL) {
-        watch *neww = worker_start_watching (ctx->wrk, npath, di->path, ctx->w->flags, WATCH_DEPENDENCY);
+    watch *neww = worker_add_subwatch (ctx->wrk, ctx->w, di);
         if (neww == NULL) {
-            perror_msg ("Failed to start watching on a new dependency %s", npath);
+            perror_msg ("Failed to start watching on a new dependency %s", di->path);
         } else {
-            neww->parent = ctx->w;
             if (neww->is_really_dir) {
                 addMask = IN_ISDIR;
             }
         }
-        free (npath);
-    } else {
-        perror_msg ("Failed to allocate a path to start watching a dependency");
-    }
 
     enqueue_event (ctx->wrk, ctx->w->fd, IN_CREATE | addMask, 0, di->path);
 }

--- a/worker.c
+++ b/worker.c
@@ -301,7 +301,7 @@ worker_add_watch (worker     *wrk,
     assert (wrk != NULL);
     assert (path != NULL);
 
-    int fd = watch_open (NULL, path);
+    int fd = watch_open (AT_FDCWD, path);
     if (fd == -1) {
         perror_msg ("Failed to open watch %s", path);
         return NULL;
@@ -316,7 +316,7 @@ worker_add_watch (worker     *wrk,
 
     dep_list *deps = NULL;
     if (S_ISDIR (st.st_mode)) {
-        deps = dl_listing (path);
+        deps = dl_listing (fd);
         if (deps == NULL) {
             perror_msg ("Directory listing of %s failed", path);
             close (fd);
@@ -365,9 +365,9 @@ worker_add_subwatch (worker *wrk, watch *parent, dep_item *di)
     assert (parent != NULL);
     assert (di != NULL);
 
-    int fd = watch_open (parent->filename, di->path);
+    int fd = watch_open (parent->fd, di->path);
     if (fd == -1) {
-        perror_msg ("Failed to open file %s/%s", parent->filename, di->path);
+        perror_msg ("Failed to open file %s", di->path);
         return NULL;
     }
 

--- a/worker.h
+++ b/worker.h
@@ -88,12 +88,7 @@ struct worker {
 worker* worker_create         ();
 void    worker_free           (worker *wrk);
 
-watch*
-worker_start_watching (worker      *wrk,
-                       const char  *path,
-                       const char  *entry_name,
-                       uint32_t     flags,
-                       watch_type_t type);
+watch*  worker_add_subwatch   (worker *wrk, watch *parent, dep_item *di);
 
 int     worker_add_or_modify  (worker *wrk, const char *path, uint32_t flags);
 int     worker_remove         (worker *wrk, int id);


### PR DESCRIPTION
Use POSIX.1-2008 relative pathname functions for file operations.
Now we can still process events on watched directory contents after directory itself has been renamed.

Compatibility shim for old OSes provided