### PR TITLE
Make most of internal processing inotify-watch centric

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -14,6 +14,7 @@ libinotify_la_SOURCES = \
     compat.c \
     conversions.c \
     dep-list.c \
+    inotify-watch.c \
     watch.c \
     worker-sets.c \
     worker-thread.c \

--- a/inotify-watch.c
+++ b/inotify-watch.c
@@ -20,4 +20,277 @@
   THE SOFTWARE.
 *******************************************************************************/
 
+#include <sys/types.h>
+#include <sys/stat.h>  /* fstat */
+
+#include <assert.h>    /* assert */
+#include <fcntl.h>     /* AT_FDCWD */
+#include <stdint.h>    /* uint32_t */
+#include <stdlib.h>    /* calloc, free */
+#include <string.h>    /* strcmp */
+#include <unistd.h>    /* close */
+
+#include "sys/inotify.h"
+
+#include "compat.h"
+#include "conversions.h"
 #include "inotify-watch.h"
+#include "utils.h"
+#include "watch.h"
+#include "worker-sets.h"
+
+/**
+ * Initialize inotify watch.
+ *
+ * This function creates and initializes additional watches for a directory.
+ *
+ * @param[in] wrk    A pointer to #worker.
+ * @param[in] path   Path to watch.
+ * @param[in] flags  A combination of inotify event flags.
+ * @return A pointer to a created #i_watch on success NULL otherwise
+ **/
+i_watch *
+iwatch_init (worker     *wrk,
+             const char *path,
+             uint32_t    flags)
+{
+    assert (wrk != NULL);
+    assert (path != NULL);
+
+    int fd = watch_open (AT_FDCWD, path, flags);
+    if (fd == -1) {
+        perror_msg ("Failed to open watch %s", path);
+        return NULL;
+    }
+
+    struct stat st;
+    if (fstat (fd, &st) == -1) {
+        perror_msg ("fstat failed on %d", fd);
+        close (fd);
+        return NULL;
+    }
+
+    dep_list *deps = NULL;
+    if (S_ISDIR (st.st_mode)) {
+        deps = dl_listing (fd);
+        if (deps == NULL) {
+            perror_msg ("Directory listing of %s failed", path);
+            close (fd);
+            return NULL;
+        }
+    }
+
+    i_watch *iw = calloc (1, sizeof (i_watch));
+    if (iw == NULL) {
+        perror_msg ("Failed to allocate inotify watch");
+        if (S_ISDIR (st.st_mode)) {
+            dl_free (deps);
+        }
+        close (fd);
+        return NULL;
+    }
+    iw->deps = deps;
+    iw->wrk = wrk;
+    iw->wd = fd;
+
+    if (worker_sets_init (&iw->watches) == -1) {
+        if (S_ISDIR (st.st_mode)) {
+            dl_free (deps);
+        }
+        close (fd);
+        free (iw);
+        return NULL;
+    }
+
+    watch *parent = watch_init (WATCH_USER, iw->wrk->kq, path, fd, flags);
+    if (parent == NULL) {
+        worker_sets_free (&iw->watches);
+        if (S_ISDIR (st.st_mode)) {
+            dl_free (deps);
+        }
+        close (fd);
+        free (iw);
+        return NULL;
+    }
+
+    if (worker_sets_insert (&iw->watches, parent)) {
+        if (S_ISDIR (st.st_mode)) {
+            dl_free (deps);
+        }
+        watch_free (parent);
+        free (iw);
+        return NULL;
+    }
+
+    if (S_ISDIR (st.st_mode)) {
+
+        dep_node *iter;
+        SLIST_FOREACH (iter, &iw->deps->head, next) {
+            watch *neww = iwatch_add_subwatch (iw, iter->item);
+            if (neww == NULL) {
+                perror_msg ("Failed to start watching a dependency %s of %s",
+                            iter->item->path,
+                            parent->filename);
+            }
+        }
+    }
+    return iw;
+}
+
+/**
+ * Free an inotify watch.
+ *
+ * @param[in] iw      A pointer to #i_watch to remove.
+ **/
+void
+iwatch_free (i_watch *iw)
+{
+    assert (iw != NULL);
+
+    worker_sets_free (&iw->watches);
+    if (iw->deps != NULL) {
+        dl_free (iw->deps);
+    }
+    free (iw);
+}
+
+/**
+ * Start watching a file or a directory.
+ *
+ * @param[in] iw A pointer to #i_watch.
+ * @param[in] di A dependency item with relative path to watch.
+ * @return A pointer to a created watch.
+ **/
+watch*
+iwatch_add_subwatch (i_watch *iw, const dep_item *di)
+{
+    assert (iw != NULL);
+    assert (iw->deps != NULL);
+    assert (di != NULL);
+
+    int fd = watch_open (iw->wd, di->path, IN_DONT_FOLLOW);
+    if (fd == -1) {
+        perror_msg ("Failed to open file %s", di->path);
+        return NULL;
+    }
+
+    watch *w = watch_init (WATCH_DEPENDENCY,
+                           iw->wrk->kq,
+                           di->path,
+                           fd,
+                           iw->watches.watches[0]->flags);
+    if (w == NULL) {
+        close (fd);
+        return NULL;
+    }
+
+    if (worker_sets_insert (&iw->watches, w)) {
+        watch_free (w);
+        return NULL;
+    }
+
+    return w;
+}
+
+/**
+ * Remove a watch from worker by its path.
+ *
+ * @param[in] iw A pointer to the #i_watch.
+ * @param[in] di A dependency list item to remove watch.
+ **/
+void
+iwatch_del_subwatch (i_watch *iw, const dep_item *di)
+{
+    assert (iw != NULL);
+    assert (di != NULL);
+
+    size_t i;
+
+    for (i = 0; i < iw->watches.length; i++) {
+        watch *w = iw->watches.watches[i];
+
+        if ((di->inode == w->inode)
+          && (strcmp (di->path, w->filename) == 0)) {
+            worker_sets_delete (&iw->watches, i);
+            break;
+        }
+    }
+}
+
+/**
+ * Update inotify watch flags.
+ *
+ * When called for a directory watch, update also the flags of all the
+ * dependent (child) watches.
+ *
+ * @param[in] iw    A pointer to #i_watch.
+ * @param[in] flags A combination of the inotify watch flags.
+ **/
+void
+iwatch_update_flags (i_watch *iw, uint32_t flags)
+{
+    assert (iw != NULL);
+
+    size_t i;
+    for (i = 0; i < iw->watches.length; i++) {
+        watch *w = iw->watches.watches[i];
+        w->flags = flags;
+        uint32_t fflags = inotify_to_kqueue (flags,
+                                             w->is_really_dir,
+                                             w->type != WATCH_USER);
+        watch_register_event (w, iw->wrk->kq, fflags);
+    }
+}
+
+/**
+ * Update path of child watch for a specified watch.
+ *
+ * It is necessary when renames in the watched directory occur.
+ *
+ * @param[in] iw     A pointer to #i_watch.
+ * @param[in] from   A rename from. Must be child of the specified parent.
+ * @param[in] to     A rename to. Must be child of the specified parent.
+ **/
+void
+iwatch_rename_subwatch (i_watch *iw, dep_item *from, dep_item *to)
+{
+    assert (iw != NULL);
+    assert (from != NULL);
+    assert (to != NULL);
+
+    size_t i;
+
+    for (i = 0; i < iw->watches.length; i++) {
+        watch *w = iw->watches.watches[i];
+
+        if ((from->inode == w->inode)
+          && (strcmp (from->path, w->filename) == 0)) {
+            free (w->filename);
+            w->filename = strdup (to->path);
+            break;
+        }
+    }
+}
+
+/**
+ * Check if a file under given path is/was a directory. Use worker's
+ * cached data (watches) to query file type (this function is called
+ * when something happens in a watched directory, so we SHOULD have
+ * a watch for its contents
+ *
+ * @param[in] iw  A inotify watch for which a change has been triggered.
+ * @param[in] di  A dependency list item
+ *
+ * @return 1 if dir (cached), 0 otherwise.
+ **/
+int
+iwatch_subwatch_is_dir (i_watch *iw, const dep_item *di)
+{
+    int i;
+    for (i = 0; i < iw->watches.length; i++) {
+        const watch *w = iw->watches.watches[i];
+        if (w != NULL && strcmp (di->path, w->filename) == 0 && w->is_really_dir)
+            return 1;
+    }
+    return 0;
+}

--- a/inotify-watch.c
+++ b/inotify-watch.c
@@ -1,0 +1,23 @@
+/*******************************************************************************
+  Copyright (c) 2014 Vladimir Kondratiev <wulf@cicgroup.ru>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*******************************************************************************/
+
+#include "inotify-watch.h"

--- a/inotify-watch.h
+++ b/inotify-watch.h
@@ -25,6 +25,8 @@
 
 #include "compat.h"
 
+#include <stdint.h>
+
 typedef struct i_watch i_watch;
 
 #include "dep-list.h"
@@ -38,5 +40,15 @@ struct i_watch {
     worker_sets watches;       /* kqueue watches of inotify watch */
     SLIST_ENTRY(i_watch) next; /* pointer to the next inotify watch in list */
 };
+
+i_watch *iwatch_init (worker *wrk, const char *path, uint32_t flags);
+void     iwatch_free (i_watch *iw);
+
+void     iwatch_update_flags    (i_watch *iw, uint32_t flags);
+
+watch*   iwatch_add_subwatch    (i_watch *iw, const dep_item *di);
+void     iwatch_del_subwatch    (i_watch *iw, const dep_item *di);
+void     iwatch_rename_subwatch (i_watch *iw, dep_item *from, dep_item *to);
+int      iwatch_subwatch_is_dir (i_watch *iw, const dep_item *di);
 
 #endif /* __INOTIFY_WATCH_H__ */

--- a/inotify-watch.h
+++ b/inotify-watch.h
@@ -1,0 +1,26 @@
+/*******************************************************************************
+  Copyright (c) 2014 Vladimir Kondratiev <wulf@cicgroup.ru>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*******************************************************************************/
+
+#ifndef __INOTIFY_WATCH_H__
+#define __INOTIFY_WATCH_H__
+
+#endif /* __INOTIFY_WATCH_H__ */

--- a/inotify-watch.h
+++ b/inotify-watch.h
@@ -23,4 +23,20 @@
 #ifndef __INOTIFY_WATCH_H__
 #define __INOTIFY_WATCH_H__
 
+#include "compat.h"
+
+typedef struct i_watch i_watch;
+
+#include "dep-list.h"
+#include "worker-sets.h"
+#include "worker.h"
+
+struct i_watch {
+    int wd;                    /* watch descriptor */
+    worker *wrk;               /* pointer to a parent worker structure */
+    dep_list *deps;            /* dependence list of inotify watch */
+    worker_sets watches;       /* kqueue watches of inotify watch */
+    SLIST_ENTRY(i_watch) next; /* pointer to the next inotify watch in list */
+};
+
 #endif /* __INOTIFY_WATCH_H__ */

--- a/inotify-watch.h
+++ b/inotify-watch.h
@@ -36,6 +36,7 @@ typedef struct i_watch i_watch;
 struct i_watch {
     int wd;                    /* watch descriptor */
     worker *wrk;               /* pointer to a parent worker structure */
+    uint32_t flags;            /* flags in the inotify format */
     dep_list *deps;            /* dependence list of inotify watch */
     worker_sets watches;       /* kqueue watches of inotify watch */
     SLIST_ENTRY(i_watch) next; /* pointer to the next inotify watch in list */

--- a/watch.c
+++ b/watch.c
@@ -68,15 +68,6 @@ _file_information (int fd, int *is_dir, ino_t *inode)
     }
 }
 
-
-
-#define DEPS_EXCLUDED_FLAGS \
-    ( IN_MOVED_FROM \
-    | IN_MOVED_TO \
-    | IN_MOVE_SELF \
-    | IN_DELETE_SELF \
-    )
-
 /**
  * Register vnode kqueue watch in kernel kqueue(2) subsystem
  *
@@ -167,13 +158,7 @@ watch_init (watch_type_t   watch_type,
     }
 
     w->fd = fd;
-
-    if (watch_type == WATCH_DEPENDENCY) {
-        flags &= ~DEPS_EXCLUDED_FLAGS;
-    }
-
     w->type = watch_type;
-    w->flags = flags;
     w->filename = strdup (path);
 
     int is_dir = 0;

--- a/watch.c
+++ b/watch.c
@@ -203,9 +203,6 @@ watch_free (watch *w)
     if (w->fd != -1) {
         close (w->fd);
     }
-    if (w->type == WATCH_USER && w->is_directory && w->deps) {
-        dl_free (w->deps);
-    }
     free (w->filename);
     free (w);
 }

--- a/watch.h
+++ b/watch.h
@@ -37,8 +37,6 @@ typedef struct watch {
     int is_directory;         /* legacy. 1 if directory IF AND ONLY IF it is a
                                * USER watch. 0 otherwise. TODO: rename this field */
     int is_really_dir;        /* a flag, a directory or not. */
-
-    uint32_t flags;           /* flags in the inotify format */
     char *filename;           /* file name of a watched file
                                * NB: an entry file name for dependencies! */
     int fd;                   /* file descriptor of a watched entry */

--- a/watch.h
+++ b/watch.h
@@ -26,8 +26,6 @@
 #include <stdint.h>    /* uint32_t */
 #include <dirent.h>    /* ino_t */
 
-#include "dep-list.h"
-
 typedef enum watch_type {
     WATCH_USER,
     WATCH_DEPENDENCY,
@@ -45,11 +43,6 @@ typedef struct watch {
                                * NB: an entry file name for dependencies! */
     int fd;                   /* file descriptor of a watched entry */
     ino_t inode;              /* inode number for the watched entry */
-
-    union {
-        dep_list *deps;       /* dependencies for an user-defined watch */
-        struct watch *parent; /* parent watch for an automatic (dependency) watch */
-    };
 } watch;
 
 int    watch_open (int dirfd, const char *path, uint32_t flags);

--- a/worker-sets.c
+++ b/worker-sets.c
@@ -37,6 +37,8 @@
 
 #define WS_RESERVED 10
 
+static int worker_sets_extend (worker_sets *ws, int count);
+
 /**
  * Initialize the worker sets.
  *
@@ -65,7 +67,7 @@ worker_sets_init (worker_sets *ws)
  * @param[in] count The number of items to grow.
  * @return 0 on success, -1 on error.
  **/
-int
+static int
 worker_sets_extend (worker_sets *ws,
                     int          count)
 {
@@ -131,4 +133,28 @@ worker_sets_delete (worker_sets *ws, size_t index)
 
     --ws->length;
     ws->watches[ws->length] = NULL;
+}
+
+/**
+ * Insert watch into worker sets.
+ *
+ * @param[in] ws A pointer to #worker_sets.
+ * @param[in] w  A pointer to inserted watch.
+ * @return 0 on success, -1 on error.
+ **/
+int
+worker_sets_insert (worker_sets *ws, watch *w)
+{
+    assert (ws != NULL);
+    assert (w != NULL);
+
+    if (worker_sets_extend (ws, 1) == -1) {
+        perror_msg ("Failed to extend worker sets");
+        return -1;
+    }
+
+    ws->watches[ws->length] = w;
+    ++ws->length;
+
+    return 0;
 }

--- a/worker-sets.h
+++ b/worker-sets.h
@@ -35,9 +35,9 @@ typedef struct worker_sets {
 } worker_sets;
 
 int  worker_sets_init   (worker_sets *ws);
-int  worker_sets_extend (worker_sets *ws, int count);
 void worker_sets_free   (worker_sets *ws);
 void worker_sets_delete (worker_sets *ws, size_t index);
+int  worker_sets_insert (worker_sets *ws, watch *w);
 
 
 #endif /* __WORKER_SETS_H__ */

--- a/worker-thread.c
+++ b/worker-thread.c
@@ -33,6 +33,7 @@
 
 #include "utils.h"
 #include "conversions.h"
+#include "inotify-watch.h"
 #include "worker.h"
 #include "worker-sets.h"
 #include "worker-thread.h"
@@ -43,20 +44,20 @@ static void handle_moved (void *udata, dep_item *from_di, dep_item *to_di);
 /**
  * Create a new inotify event and place it to event queue.
  *
- * @param[in] wrk    A pointer to #worker. 
- * @param[in] wd     An associated watch's id.
+ * @param[in] iw     A pointer to #i_watch.
  * @param[in] mask   An inotify watch mask.
  * @param[in] cookie Event cookie.
  * @param[in] name   File name (may be NULL).
  * @return 0 on success, -1 otherwise.
  **/
 int
-enqueue_event (worker     *wrk,
-               int         wd,
+enqueue_event (i_watch    *iw,
                uint32_t    mask,
                uint32_t    cookie,
                const char *name)
 {
+    assert (iw != NULL);
+    worker *wrk = iw->wrk;
     assert (wrk != NULL);
 
     if (wrk->iovcnt >= wrk->iovalloc) {
@@ -70,7 +71,7 @@ enqueue_event (worker     *wrk,
         wrk->iovalloc = to_allocate;
     }
 
-    wrk->iov[wrk->iovcnt].iov_base = create_inotify_event (wd, mask,
+    wrk->iov[wrk->iovcnt].iov_base = create_inotify_event (iw->wd, mask,
         cookie, name, &wrk->iov[wrk->iovcnt].iov_len);
 
     if (wrk->iov[wrk->iovcnt].iov_base != NULL) {
@@ -109,17 +110,17 @@ flush_events (worker *wrk)
  * when something happens in a watched directory, so we SHOULD have
  * a watch for its contents
  *
- * @param[in] wrk A worker instance for which a change has been triggered.
+ * @param[in] iw  A inotify watch for which a change has been triggered.
  * @param[in] di  A dependency list item
  *
  * @return 1 if dir (cached), 0 otherwise.
  **/
 static int
-check_is_dir_cached (worker *wrk, const dep_item *di)
+check_is_dir_cached (i_watch *iw, const dep_item *di)
 {
     int i;
-    for (i = 0; i < wrk->sets.length; i++) {
-        const watch *w = wrk->sets.watches[i];
+    for (i = 0; i < iw->watches.length; i++) {
+        const watch *w = iw->watches.watches[i];
         if (w != NULL && strcmp (di->path, w->filename) == 0 && w->is_really_dir)
             return 1;
     }
@@ -162,8 +163,7 @@ process_command (worker *wrk)
  * the callbacks.
  **/
 typedef struct {
-    worker *wrk;
-    watch *w;
+    i_watch *iw;
 } handle_context;
 
 /**
@@ -181,11 +181,10 @@ handle_added (void *udata, dep_item *di)
     assert (udata != NULL);
 
     handle_context *ctx = (handle_context *) udata;
-    assert (ctx->wrk != NULL);
-    assert (ctx->w != NULL);
+    assert (ctx->iw != NULL);
 
     int addMask = 0;
-    watch *neww = worker_add_subwatch (ctx->wrk, ctx->w, di);
+    watch *neww = worker_add_subwatch (ctx->iw, di);
         if (neww == NULL) {
             perror_msg ("Failed to start watching on a new dependency %s", di->path);
         } else {
@@ -194,7 +193,7 @@ handle_added (void *udata, dep_item *di)
             }
         }
 
-    enqueue_event (ctx->wrk, ctx->w->fd, IN_CREATE | addMask, 0, di->path);
+    enqueue_event (ctx->iw, IN_CREATE | addMask, 0, di->path);
 }
 
 /**
@@ -212,12 +211,11 @@ handle_removed (void *udata, dep_item *di)
     assert (udata != NULL);
 
     handle_context *ctx = (handle_context *) udata;
-    assert (ctx->wrk != NULL);
-    assert (ctx->w != NULL);
+    assert (ctx->iw != NULL);
 
-    int addMask = check_is_dir_cached (ctx->wrk, di) ? IN_ISDIR : 0;
-    enqueue_event (ctx->wrk, ctx->w->fd, IN_DELETE | addMask, 0, di->path);
-    worker_remove_watch (ctx->wrk, ctx->w, di);
+    int addMask = check_is_dir_cached (ctx->iw, di) ? IN_ISDIR : 0;
+    enqueue_event (ctx->iw, IN_DELETE | addMask, 0, di->path);
+    worker_remove_watch (ctx->iw, di);
 }
 
 /**
@@ -237,10 +235,9 @@ handle_replaced (void *udata, dep_item *di)
     assert (udata != NULL);
 
     handle_context *ctx = (handle_context *) udata;
-    assert (ctx->wrk != NULL);
-    assert (ctx->w != NULL);
+    assert (ctx->iw != NULL);
 
-    worker_remove_watch (ctx->wrk, ctx->w, di);
+    worker_remove_watch (ctx->iw, di);
 }
 
 /**
@@ -279,15 +276,14 @@ handle_moved (void *udata, dep_item *from_di, dep_item *to_di)
     assert (udata != NULL);
 
     handle_context *ctx = (handle_context *) udata;
-    assert (ctx->wrk != NULL);
-    assert (ctx->w != NULL);
+    assert (ctx->iw != NULL);
 
-    int addMask = check_is_dir_cached (ctx->wrk, from_di) ? IN_ISDIR : 0;
+    int addMask = check_is_dir_cached (ctx->iw, from_di) ? IN_ISDIR : 0;
     uint32_t cookie = from_di->inode & 0x00000000FFFFFFFF;
 
-    enqueue_event (ctx->wrk, ctx->w->fd, IN_MOVED_FROM | addMask, cookie, from_di->path);
-    enqueue_event (ctx->wrk, ctx->w->fd, IN_MOVED_TO | addMask, cookie, to_di->path);
-    worker_rename_watch (ctx->wrk, ctx->w, from_di, to_di);
+    enqueue_event (ctx->iw, IN_MOVED_FROM | addMask, cookie, from_di->path);
+    enqueue_event (ctx->iw, IN_MOVED_TO | addMask, cookie, to_di->path);
+    worker_rename_watch (ctx->iw, from_di, to_di);
 }
 
 
@@ -309,40 +305,33 @@ static const traverse_cbs cbs = {
  * This function is top-level and it operates with other specific routines
  * to notify about different sets of events in a different conditions.
  *
- * @param[in] wrk   A pointer to #worker.
- * @param[in] w     A pointer to #watch.
+ * @param[in] iw    A pointer to #i_watch.
  * @param[in] event A pointer to the received kqueue event.
  **/
 void
-produce_directory_diff (worker *wrk, watch *w, struct kevent *event)
+produce_directory_diff (i_watch *iw, struct kevent *event)
 {
-    assert (wrk != NULL);
-    assert (w != NULL);
+    assert (iw != NULL);
     assert (event != NULL);
 
-    assert (w->type == WATCH_USER);
-    assert (w->is_directory);
-
     dep_list *was = NULL, *now = NULL;
-    was = w->deps;
-    now = dl_listing (w->fd);
+    was = iw->deps;
+    now = dl_listing (iw->wd);
     if (now == NULL) {
-        perror_msg ("Failed to create a listing for directory %s",
-                    w->filename);
+        perror_msg ("Failed to create a listing for watch %d", iw->wd);
         return;
     }
 
-    w->deps = now;
+    iw->deps = now;
 
     handle_context ctx;
     memset (&ctx, 0, sizeof (ctx));
-    ctx.wrk = wrk;
-    ctx.w = w;
+    ctx.iw = iw;
     
     if (dl_calculate (was, now, &cbs, &ctx) == -1) {
-        w->deps = was;
+        iw->deps = was;
         dl_free (now);
-        perror_msg ("Failed to produce directory diff for %s", w->filename);
+        perror_msg ("Failed to produce directory diff for watch %d", iw->wd);
     }
 }
 
@@ -359,14 +348,20 @@ produce_notifications (worker *wrk, struct kevent *event)
     assert (event != NULL);
 
     watch *w = NULL;
+    i_watch *iw = NULL;
     size_t i;
 
-    for (i = 0; i < wrk->sets.length; i++) {
-        if (event->ident == wrk->sets.watches[i]->fd) {
-            w = wrk->sets.watches[i];
-            break;
+    SLIST_FOREACH (iw, &wrk->head, next) {
+        for (i = 0; i < iw->watches.length; i++) {
+            if (event->ident == iw->watches.watches[i]->fd) {
+                w = iw->watches.watches[i];
+                goto found;
+            }
         }
     }
+
+found:
+    assert (iw != NULL);
     assert (w != NULL);
 
     uint32_t flags = event->fflags;
@@ -378,28 +373,24 @@ produce_notifications (worker *wrk, struct kevent *event)
         }
 
         if (flags & NOTE_WRITE && w->is_directory) {
-            produce_directory_diff (wrk, w, event);
+            produce_directory_diff (iw, event);
             flags &= ~(NOTE_WRITE | NOTE_EXTEND | NOTE_LINK);
         }
 
         if (flags) {
-            enqueue_event (wrk,
-                           w->fd,
+            enqueue_event (iw,
                            kqueue_to_inotify (flags, w->is_really_dir, 0),
                            0,
                            NULL);
         }
 
         if (flags & NOTE_DELETE) {
-            worker_remove (wrk, w->fd);
+            worker_remove (wrk, iw->wd);
         }
     } else {
         /* for dependency events, ignore some notifications */
         if (flags & (NOTE_ATTRIB | NOTE_LINK | NOTE_WRITE)) {
-            watch *p = w->parent;
-            assert (p != NULL);
-            enqueue_event (wrk,
-                           p->fd,
+            enqueue_event (iw,
                            kqueue_to_inotify (flags, w->is_really_dir, 1),
                            0,
                            w->filename);

--- a/worker-thread.c
+++ b/worker-thread.c
@@ -291,6 +291,7 @@ handle_moved (void *udata, dep_item *from_di, dep_item *to_di)
 
     enqueue_event (ctx->wrk, ctx->w->fd, IN_MOVED_FROM | addMask, cookie, from_di->path);
     enqueue_event (ctx->wrk, ctx->w->fd, IN_MOVED_TO | addMask, cookie, to_di->path);
+    worker_rename_watch (ctx->wrk, ctx->w, from_di, to_di);
 }
 
 /**
@@ -313,26 +314,6 @@ handle_many_removed (void *udata, const dep_list *list)
     }
 }
 
-/**
- * Update file names for the renamed files.
- *
- * This function is used as a callback and is invoked from the dep-list
- * routines.
- *
- * @param[in] udata  A pointer to user data (#handle_context).
- **/
-static void
-handle_names_updated (void *udata)
-{
-    assert (udata != NULL);
-
-    handle_context *ctx = (handle_context *) udata;
-    assert (ctx->wrk != NULL);
-    assert (ctx->w != NULL);
-
-    worker_update_paths (ctx->wrk, ctx->w);
-}
-
 
 static const traverse_cbs cbs = {
     NULL, /* handle_unchanged */
@@ -343,7 +324,7 @@ static const traverse_cbs cbs = {
     handle_moved,
     NULL, /* many_added */
     handle_many_removed,
-    handle_names_updated,
+    NULL, /* names_updated */
 };
 
 /**

--- a/worker-thread.h
+++ b/worker-thread.h
@@ -23,11 +23,11 @@
 #ifndef __WORKER_THREAD_H__
 #define __WORKER_THREAD_H__
 
+#include "inotify-watch.h"
 #include "worker.h"
 
 void* worker_thread (void *arg);
-int   enqueue_event (worker     *wrk,
-                     int         wd,
+int   enqueue_event (i_watch    *iw,
                      uint32_t    mask,
                      uint32_t    cookie,
                      const char *name);

--- a/worker.c
+++ b/worker.c
@@ -270,18 +270,13 @@ worker_start_watching (worker      *wrk,
     assert (wrk != NULL);
     assert (path != NULL);
 
-    if (worker_sets_extend (&wrk->sets, 1) == -1) {
-        perror_msg ("Failed to extend worker sets");
-        return NULL;
-    }
-
     watch *w = watch_init (type, wrk->kq, path, fd, flags);
-    if (w == NULL) {
-        return NULL;
+    if (w != NULL) {
+        if (worker_sets_insert (&wrk->sets, w)) {
+            watch_free (w);
+            w = NULL;
+        }
     }
-    wrk->sets.watches[wrk->sets.length] = w;
-
-    ++wrk->sets.length;
 
     return w;
 }

--- a/worker.h
+++ b/worker.h
@@ -89,12 +89,7 @@ struct worker {
 worker* worker_create         ();
 void    worker_free           (worker *wrk);
 
-watch*  worker_add_subwatch   (i_watch *iw, dep_item *di);
-
 int     worker_add_or_modify  (worker *wrk, const char *path, uint32_t flags);
 int     worker_remove         (worker *wrk, int id);
-
-void    worker_remove_watch   (i_watch *iw, const dep_item* item);
-void    worker_rename_watch   (i_watch *iw, dep_item *from, dep_item *to);
 
 #endif /* __WORKER_H__ */

--- a/worker.h
+++ b/worker.h
@@ -32,8 +32,9 @@ typedef struct worker worker;
 
 #include "compat.h"
 #include "worker-thread.h"
-#include "worker-sets.h"
 #include "dep-list.h"
+#include "inotify-watch.h"
+#include "watch.h"
 
 #define INOTIFY_FD 0
 #define KQUEUE_FD  1
@@ -77,7 +78,7 @@ struct worker {
     int iovcnt;            /* number of events enqueued */
     int iovalloc;          /* number of iovs allocated */
     pthread_t thread;      /* worker thread */
-    worker_sets sets;      /* filenames, etc */
+    SLIST_HEAD(, i_watch) head; /* linked list of inotify watches */
     volatile int closed;   /* closed flag */
 
     pthread_mutex_t mutex; /* worker mutex */
@@ -88,12 +89,12 @@ struct worker {
 worker* worker_create         ();
 void    worker_free           (worker *wrk);
 
-watch*  worker_add_subwatch   (worker *wrk, watch *parent, dep_item *di);
+watch*  worker_add_subwatch   (i_watch *iw, dep_item *di);
 
 int     worker_add_or_modify  (worker *wrk, const char *path, uint32_t flags);
 int     worker_remove         (worker *wrk, int id);
 
-void    worker_remove_watch   (worker *wrk, watch *parent, const dep_item* item);
-void    worker_rename_watch   (worker *wrk, watch *parent, dep_item *from, dep_item *to);
+void    worker_remove_watch   (i_watch *iw, const dep_item* item);
+void    worker_rename_watch   (i_watch *iw, dep_item *from, dep_item *to);
 
 #endif /* __WORKER_H__ */

--- a/worker.h
+++ b/worker.h
@@ -93,7 +93,6 @@ watch*  worker_add_subwatch   (worker *wrk, watch *parent, dep_item *di);
 int     worker_add_or_modify  (worker *wrk, const char *path, uint32_t flags);
 int     worker_remove         (worker *wrk, int id);
 
-void    worker_remove_many    (worker *wrk, watch *parent, const dep_list* items, int remove_self);
 void    worker_remove_watch   (worker *wrk, watch *parent, const dep_item* item);
 void    worker_rename_watch   (worker *wrk, watch *parent, dep_item *from, dep_item *to);
 

--- a/worker.h
+++ b/worker.h
@@ -93,8 +93,8 @@ watch*  worker_add_subwatch   (worker *wrk, watch *parent, dep_item *di);
 int     worker_add_or_modify  (worker *wrk, const char *path, uint32_t flags);
 int     worker_remove         (worker *wrk, int id);
 
-void    worker_update_paths   (worker *wrk, watch *parent);
 void    worker_remove_many    (worker *wrk, watch *parent, const dep_list* items, int remove_self);
 void    worker_remove_watch   (worker *wrk, watch *parent, const dep_item* item);
+void    worker_rename_watch   (worker *wrk, watch *parent, dep_item *from, dep_item *to);
 
 #endif /* __WORKER_H__ */


### PR DESCRIPTION
Make most of internal processing inotify-watch centric. E.g. split worker_sets on per inotify_watch basis. Hopefully no functional changes. Just moving chunks of code back and forth 