### PR TITLE
Fix hangs on FreeBSD

### DIFF
--- a/worker.c
+++ b/worker.c
@@ -150,7 +150,7 @@ worker_cmd_release (worker_cmd *cmd)
 static int
 pipe_init (int fildes[2], int flags)
 {
-    if (socketpair (AF_UNIX, SOCK_STREAM, 0, fildes) == -1) {
+    if (socketpair (AF_UNIX, SOCK_NONBLOCK|SOCK_STREAM, 0, fildes) == -1) {
         perror_msg ("Failed to create a socket pair");
         return -1;
     }


### PR DESCRIPTION
We're trying to create an fsnotifier version for FreeBSD/OpenBSD with libinotify but are running into trouble when trying to stress test it. It hangs in an `sbwait` state when trying to watch, then unwatch a lot of files. See https://github.com/idea4bsd/fsnotifier/issues/1. 

I fixed it by adding the `SOCK_NONBLOCK` option to socketpair. I'm not sure if this a proper fix. Let me know if this is ok.

The test suite passes mostly. Only tests that also fail in https://github.com/dmatveev/libinotify-kqueue/issues/33 don't. So I guess this is ok.

```
In test "Directory notifications":
    failed: receive IN_MOVED_FROM event on moving file from directory to another location within the same mount point
    failed: receive IN_MOVED_TO event on moving file to directory from another location within the same mount point

In test "Open/close notifications":
    failed: receive IN_OPEN on cat
    failed: receive IN_CLOSE_NOWRITE on cat
    failed: receive IN_OPEN on ls
    failed: receive IN_CLOSE_NOWRITE on ls
    failed: receive IN_OPEN on modify
    failed: receive IN_CLOSE_WRITE on modify

In test "Symbolic links":
    failed: Start watch successfully on a symlink file with IN_DONT_FOLLOW
    failed: Receive IN_ATTRIB after touching symlink itself
    failed: Receive IN_MOVE_SELF after moving the symlink
    failed: Receive IN_DELETE_SELF after removing the symlink

--------------------
     Run: 119
  Passed: 107
  Failed: 12
```